### PR TITLE
fix(services): fix error in restCountries

### DIFF
--- a/src/services/RestCountries.js
+++ b/src/services/RestCountries.js
@@ -6,7 +6,7 @@ export const getCountries = async () => {
     if (!response.ok) throw new Error(response.statusText);
     const json = await response.json();
     return json.map(item => {
-      return new Country(item.name.common, item.capital[0], item.flags.png)
+      return new Country(item.name.common, item.capital?.[0] ?? '' , item.flags.png)
     });
   } catch (error) {
     console.log(error)


### PR DESCRIPTION
al obtener los datos de la api RestCountries, se generaba error al acceder a la propiedad "capital" en los elementos que no poseían dicha propiedad.